### PR TITLE
Improve numerical stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project was built on `go version go1.13.9`.
 ## Usage
 
 Build n dilations by calling `UnitaryNDilation(m, n)`, where `t`  is of type `*mat.Dense` (see gonum) - the contraction that will be dilated, and `n` is of type `int` - the degree that the dilation will have.
+Note that the defect operator of `t` must have real eigenvalues.
 Import the library as github.com/acra5y/go-dilation.
 
 For ill-conditionend matrices (e.g. with high eigenvalues or eigenvalues close to 0) the result might be imprecise.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ This project was built on `go version go1.13.9`.
 
 Build n dilations by calling `UnitaryNDilation(m, n)`, where `t`  is of type `*mat.Dense` (see gonum) - the contraction that will be dilated, and `n` is of type `int` - the degree that the dilation will have.
 Import the library as github.com/acra5y/go-dilation.
+
+For ill-conditionend matrices (e.g. with high eigenvalues or eigenvalues close to 0) the result might be imprecise.

--- a/godilation_test.go
+++ b/godilation_test.go
@@ -1,0 +1,56 @@
+package godilation
+
+import (
+    "fmt"
+    "gonum.org/v1/gonum/mat"
+    "reflect"
+    "testing"
+)
+
+func TestUnitaryNDilation(t *testing.T) {
+    tables := []struct {
+        desc string
+        value *mat.Dense
+        expectedValue *mat.Dense
+        expectedErr error
+    }{
+        {
+            value: mat.NewDense(2, 2, []float64{0.5,0,0,0.2,}),
+            desc: "return a value for a contraction",
+            expectedValue: mat.NewDense(6, 6, []float64{
+                0.5, 0, 0, 0, 0.8660254037844386, 0,
+                0, 0.2, 0, 0, 0, 0.9797958971132712,
+                0.8660254037844386, 0, 0, 0, -0.5, 0,
+                0, 0.9797958971132712, 0, 0, 0, -0.2,
+                0, 0, 1, 0, 0, 0,
+                0, 0, 0, 1, 0, 0,
+            }),
+            expectedErr: nil,
+        },
+        {
+            value: mat.NewDense(2, 2, []float64{0.5,0,0,2,}),
+            desc: "return a value if matrix is not a contraction",
+            expectedValue: nil,
+            expectedErr: fmt.Errorf("Input is not a contraction"),
+        },
+    }
+    for _, table := range tables {
+        table := table
+        t.Run(table.desc, func(t *testing.T) {
+            t.Parallel()
+            value, err := UnitaryNDilation(table.value, 2)
+
+            if !reflect.DeepEqual(err, table.expectedErr) {
+                t.Errorf("Wrong error, got: %v, want: %v", err, table.expectedErr)
+            }
+
+            if table.expectedValue == nil && value != nil {
+                t.Errorf("Wrong result, got: %v, want: %v", value, table.expectedValue)
+            }
+
+            if table.expectedValue != nil && !mat.Equal(value, table.expectedValue) {
+                t.Errorf("Wrong result, got: %v, want: %v", value, table.expectedValue)
+            }
+        })
+    }
+}

--- a/internal/dilation/dilation.go
+++ b/internal/dilation/dilation.go
@@ -53,6 +53,18 @@ func UnitaryNDilation(isPD isPositiveDefinite, sqrt squareRoot, newBlockMatrix n
     }
 
     defectSquaredOfTranspose := defectOperatorSquared(t.T())
+    /*
+        We can calculate the square root as it must exist as we assume T is a positive definite contraction:
+        Let T be a positiv definite complex matrix of dimension n times n with ||T|| < 1 (where ||T|| denotes the operator norm).
+        Let T^* denote the conjugate transpose of T.
+        The equivalency (T^*T)^* = (T^*)(T^*)^* = (T^*)T shows T^*T is hermitian.
+        Let I by the eye Matrix of the same dimension as T.
+        It follows that for a given vector v and the euclidean norm |v|: v^*(I − T^*T)v = v^*Iv − v^*T^*Tv = v^*v − (Tv)^*Tv = |v|^2 − |Tv|^2 > 0.
+        The last step ist based on the requirement that ||T|| < 1.
+        For a positive definite matrix we then know that a square root must exist.
+        See also "Harmonic Analysis of Operators on Hilbert Space" by  B. Sz.-Nagy, chapter I, 1. in section 3.
+        (Please note this hint does not have the ambition to be a mathematical proof on its own).
+    */
     defect, _ := sqrt(defectSquared)
     defectOfTransposed, _ := sqrt(defectSquaredOfTranspose)
 

--- a/internal/squareRoot/squareRoot_test.go
+++ b/internal/squareRoot/squareRoot_test.go
@@ -12,7 +12,10 @@ func TestCalculate(t *testing.T) {
         desc string
         value *mat.Dense
     }{
-        {value: mat.NewDense(2, 2, []float64{1,0,0,1,}), desc: "square root"},
+        {value: mat.NewDense(2, 2, []float64{1,0,0,1,}), desc: "for eye matrix"},
+        {value: mat.NewDense(3,3, []float64{0.9879, 0.0011, 0.0132, 0.0011, 0.9598, 0, 0.0132, 0, 0.9712}), desc:"for a random non diagonal p.d. matrix"},
+        {value: mat.NewDense(3,3, []float64{0.1,0,0.3,0, 0.12, 0.1412,0, 0, 0.12}), desc:"for a random non diagonal p.d. matrix 2"},
+        {value: mat.NewDense(3,3, []float64{2, -1, 0, -1, 2, -1,0, -1, 2}), desc:"for a random non diagonal p.d. matrix 3"},
     }
 
     for _, table := range tables {
@@ -25,8 +28,15 @@ func TestCalculate(t *testing.T) {
                 t.Errorf("Error: %v.", err)
             }
 
-            if !mat.Equal(res, table.value) {
-                t.Errorf("Wrong result, got: %v, want: %v", res, table.value)
+            n, _ := res.Dims()
+            value := mat.NewDense(n, n, nil)
+            value.Pow(res, 2)
+            diff := mat.NewDense(n, n, nil)
+            diff.Sub(table.value, value)
+            norm := mat.Norm(diff, 2)
+
+            if norm >= 1e-3 {
+                t.Errorf("Wrong result, got: %v, want: %v, norm difference %e", value, table.value, norm)
             }
         })
     }


### PR DESCRIPTION
* Instead of calculating the inverse of a matrix numerically, solve a set of linear equations. This is more stable (as also stated in docs of gonum)